### PR TITLE
Add basic drag & drop functionality to color instances

### DIFF
--- a/src/routes/mix.svelte
+++ b/src/routes/mix.svelte
@@ -17,6 +17,8 @@
 
   let colorInstances: Color[] = queryColors || [Color.random(), Color.random()]
 
+  let dragColorIndex = -1
+
   let stepsCount =
     Number(getQueryParam('steps', localStorage.getItem('steps'))) || 10
 
@@ -92,6 +94,27 @@
     )
   }
 
+  const onDrop = (index) => {
+    if (dragColorIndex === -1 || dragColorIndex === index) {
+      return;
+    }
+    const instancesWithoutDragColor = colorInstances.filter((_, i) => i !== dragColorIndex)
+    colorInstances = [
+      ...instancesWithoutDragColor.slice(0, index),
+      colorInstances[dragColorIndex],
+      ...instancesWithoutDragColor.slice(index)
+    ]
+    onColorChange()
+  }
+
+  const onDrag = (index) => {
+    dragColorIndex = index;
+  }
+
+  const onDragEnd = () => {
+    dragColorIndex = -1;
+  }
+
   onColorChange()
 </script>
 
@@ -127,8 +150,15 @@
       </div>
 
       <div class="flex-1 flex flex-col space-y-4">
-        {#each colorInstances as colorInstance, index (index)}
-          <div class="flex-1 flex flex-col">
+        {#each colorInstances as colorInstance, index (colorInstance)}
+          <div
+            class="flex-1 flex flex-col"
+            draggable="true"
+            on:dragstart={() => onDrag(index)}
+            on:drop|preventDefault={() => onDrop(index)}
+            on:dragover|preventDefault
+            on:dragend={onDragEnd}
+          >
             <ColorCard
               deletable={colorInstances.length > 2}
               bind:color={colorInstance}


### PR DESCRIPTION
Hey @pabueco, thanks for the great tool! I was playing around with it and felt a drag and drop interaction for the color mixer would be handy. If it's something you're interested in including please check out this PR. It includes a simple version that relies on the HTML API (see gif below).

![drag](https://user-images.githubusercontent.com/4415071/154439464-7339e6b1-39ab-408e-b0f4-100925912e65.gif)
