### PR TITLE
Improve cursor feel

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -18,7 +18,7 @@
 
     %svelte.head%
   </head>
-  <body class="bg-gray-900 font-sans">
+  <body class="bg-gray-900 font-sans cursor-default select-none">
     <div id="svelte">%svelte.body%</div>
   </body>
 </html>


### PR DESCRIPTION
Adds `cursor-default` and `select-none` to \<body> to help with feel

Inputs are still selectable and show the selection cursor

Tested in Firefox 97 and Chromium 98

Thanks for sharing this neat app :slightly_smiling_face: 