### PR TITLE
fix: reflecting color changes instantly

### DIFF
--- a/src/components/ColorBlock.svelte
+++ b/src/components/ColorBlock.svelte
@@ -35,7 +35,7 @@
 
 <div
   style="background: {color.hex()}; color: {textColor}"
-  class="group relative min-h-[2.5rem] cursor-pointer transition duration-200 flex items-center justify-center select-none whitespace-nowrap 
+  class="group relative min-h-[2.5rem] cursor-pointer flex items-center justify-center select-none whitespace-nowrap 
     {expands ? 'w-full flex-1' : 'w-10'} 
     {animatesOnHover ? 'transform hover:scale-110' : ''} 
     {animatesOnClick ? 'active:scale-90' : ''} 
@@ -50,7 +50,7 @@
 >
   {#if showName && colorName}
     <div
-      class="text-lg font-medium opacity-80 transition hover:opacity-100 transform text-center
+      class="text-lg font-medium opacity-80 transition-opacity hover:opacity-100 transform text-center
       {compact ? 'mb-1' : 'absolute top-4 left-1/2 -translate-x-1/2'}
       "
       style="color: {textColor};"

--- a/src/components/ColorCard.svelte
+++ b/src/components/ColorCard.svelte
@@ -69,7 +69,7 @@
   style="color: {textColor}; background-color: {color.hex?.()}; box-shadow: 0 10px 30px -10px {color.chroma
     .alpha(color.chroma.alpha() - color.chroma.alpha() / 4)
     .css()}"
-  class="relative transition rounded-2xl p-4 flex-1 flex flex-col justify-end cursor-pointer group min-h-[175px]"
+  class="relative rounded-2xl p-4 flex-1 flex flex-col justify-end cursor-pointer group min-h-[175px]"
 >
   {#if deletable}
     <button
@@ -92,7 +92,7 @@
   {/if}
 
   <div
-    class="absolute top-4 text-lg font-medium opacity-80 transition hover:opacity-100 left-1/2 transform -translate-x-1/2 text-center"
+    class="absolute top-4 text-lg font-medium opacity-80 transition-opacity hover:opacity-100 left-1/2 transform -translate-x-1/2 text-center"
     style="color: {textColor};"
     on:click={(e) => copyToClipboard(e, colorName, 'Name copied!')}
   >

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -68,7 +68,7 @@
 	/> -->
 
   <div
-    class="fixed inset-0 transition"
+    class="fixed inset-0"
     style="background: {$primaryColor?.hex()};"
   />
 

--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -68,7 +68,7 @@
 	/> -->
 
   <div
-    class="fixed inset-0"
+    class="fixed inset-0 {$page.url.pathname === '/' ? 'transition' : ''}"
     style="background: {$primaryColor?.hex()};"
   />
 


### PR DESCRIPTION
Pull request for issue #10 

Removed transition classes from ColorCard and ColorBlock components. 
I also removed it for the background and text on cards (it felt not consistent and out of place, let me know if that's okay).

Tested on Firefox 97