### PR TITLE
fix: handle invalid color values

### DIFF
--- a/src/components/ColorCard.svelte
+++ b/src/components/ColorCard.svelte
@@ -34,7 +34,7 @@
 
   $: formattedColorValue = new TinyColor(color.hex()).toString(inputFormat)
 
-  $: validateColor(formattedColorValue) // run color validation on `color` prop change
+  $: validateColor(formattedColorValue) // Run color validation on `color` prop change
 
   const findColorName = () => {
     colorName = nearest(color.toString('hex')).name

--- a/src/components/ColorCard.svelte
+++ b/src/components/ColorCard.svelte
@@ -194,12 +194,11 @@
       
       {:else}
       <button
-          class="absolute left-[20px] bottom-[2px]"
+          class="absolute left-[18px] bottom-[11px]"
           title="Invalid color"
         >
-        <svg xmlns="http://www.w3.org/2000/svg" fill="red" class="h-8 w-8" viewBox="0 0 24 24" stroke="red">
-          <path stroke-width="0.7" d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
-          <path stroke-width="0.7" d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="red">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
         </svg>
       </button>
     {/if}

--- a/src/components/ColorCard.svelte
+++ b/src/components/ColorCard.svelte
@@ -34,6 +34,8 @@
 
   $: formattedColorValue = new TinyColor(color.hex()).toString(inputFormat)
 
+  $: validateColor(formattedColorValue) // run color validation on `color` prop change
+
   const findColorName = () => {
     colorName = nearest(color.toString('hex')).name
   }
@@ -46,7 +48,7 @@
   /*
     Set passed color as active if it's a valid color
   */
-  const setNewColor = async (newColor: string) => {
+  const updateColor = async (newColor: string) => {
     validateColor(newColor)
     if (!isValidColor) return
 
@@ -62,14 +64,13 @@
   /*
     Proceed with color change if the user's input isn't empty, otherwise - set default color as active
   */
-  const onColorInputChange = () => colorInput.value ? setNewColor(colorInput.value) : setNewColor(defaultColor)
+  const onColorInputChange = () => colorInput.value ? updateColor(colorInput.value) : updateColor(defaultColor)
   
   const findColorNameThrottled = throttle(() => {
     colorName = nearest(color.toString('hex')).name
   }, 400)
 
   const onColorPickerUpdate = () => {
-    validateColor(colorInput.value) // Udpate `isValidColor`
     findColorNameThrottled()
   }
 


### PR DESCRIPTION
Pull request for issue #5

Added handling clearing color input by user completely - now it sets to black.
Added validation of the color input value - stopped trying to create new `Color` instances if the value's not a valid color.
Added rendering the warning icon if the user's input isn't a valid color.

After all I settled for adding `title` property on the button instead of adding new tooltip component. Let me know what do you think about it.

Tested on Firefox 97