### PR TITLE
feat: add dynamic page color display

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -18,6 +18,7 @@
 
 <svelte:head>
   <title>hue.tools</title>
+  <meta name="theme-color" content={colorHex} />
 </svelte:head>
 
 <div class="flex-1 flex flex-col items-center justify-center relative">


### PR DESCRIPTION
This PR simply adds a `meta` property [`theme-color`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name/theme-color) to update browser user interface display creating a more "immersive experience".

The value is not yet supported in all major browsers. Having the `theme-color` property set only adds the dynamic interface color to supported browsers; it doesn't break unsupported ones.

Here's a screenshot of how it looks like in Safari

<img width="1376" alt="image" src="https://user-images.githubusercontent.com/16290753/216802674-09c2bca7-1cb4-4a47-819b-7a0cc386d334.png">
